### PR TITLE
Add stop() methods and also LICENSE/CocoaPods files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+
+Starling
+
+Released under: MIT License
+Copyright (c) 2018 by Matt Reagan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Starling.podspec
+++ b/Starling.podspec
@@ -1,0 +1,28 @@
+# coding: utf-8
+Pod::Spec.new do |spec|
+  spec.name         = "Starling"
+  spec.version      = "1.0.0"
+  spec.summary      = "Simple low-latency audio library for iOS + macOS"
+  spec.description  = <<-DESC
+Starling is a simple audio library for iOS + macOS written in
+Swift. It provides low-latency sound resource playback for games,
+real-time media solutions, or other performance-critical
+applications. It is built around Apple's AVAudioEngine and simplifies
+the API in an effort to reduce the amount of boilerplate needed for
+basic audio playback.
+                   DESC
+
+  spec.homepage     = "https://github.com/matthewreagan/Starling"
+  spec.license      = { :type => "MIT", :file => "LICENSE" }
+  spec.author             = { "Matthew Reagan" => "humblebeesoft@gmail.com" }
+
+  spec.ios.deployment_target = "11.0"
+  spec.osx.deployment_target = "10.13"
+  spec.swift_version = "5.0"
+
+  spec.source       = { :git => "https://github.com/matthewreagan/Starling.git", :tag => "#{spec.version}" }
+
+  spec.source_files  = "Starling/*.swift"
+
+  spec.frameworks = "Foundation", "AVFoundation"
+end


### PR DESCRIPTION
Hi Matthew,

One of my team has been using your convenient library to prototype some audio features. To easily integrate it with an existing codebase that uses CocoaPods I added a podspec file. It would be nice to also get the version tagged and inserted into the CocoaPods spec repo, but just adding the file to your repo will make integration cleaner.

We also added a stop() method.

Let me know if you have any comments or if you would like me to split this into two changes.